### PR TITLE
feat(assets): update exported assets from figma

### DIFF
--- a/iconTestRepo/Bg_shape.svg
+++ b/iconTestRepo/Bg_shape.svg
@@ -1,0 +1,3 @@
+<svg width="22" height="24" viewBox="0 0 22 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11 0L21.3923 6V18L11 24L0.607697 18V6L11 0Z" fill="#3B7CE2"/>
+</svg>

--- a/iconTestRepo/Vector_sliders.svg
+++ b/iconTestRepo/Vector_sliders.svg
@@ -1,0 +1,11 @@
+<svg width="12" height="14" viewBox="0 0 12 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="4.46281" cy="2.9876" r="1.4876" stroke="white" stroke-width="0.743801"/>
+<circle cx="3.47108" cy="10.9215" r="1.4876" stroke="white" stroke-width="0.743801"/>
+<circle cx="1.4876" cy="1.4876" r="1.4876" transform="matrix(1 0 0 -1 6.94214 8.44214)" stroke="white" stroke-width="0.743801"/>
+<rect y="10.4256" width="1.98347" height="0.991735" fill="white"/>
+<rect x="4.95868" y="10.4256" width="6.94215" height="0.991735" fill="white"/>
+<rect width="6.94215" height="0.991735" transform="matrix(1 0 0 -1 0 7.45041)" fill="white"/>
+<rect width="2" height="1.18182" transform="matrix(1 0 0 -1 10 7.59091)" fill="white"/>
+<rect y="2.49173" width="2.97521" height="0.991735" fill="white"/>
+<rect x="5.95041" y="2.49173" width="5.95041" height="0.991735" fill="white"/>
+</svg>

--- a/iconTestRepo/exported-assets.js
+++ b/iconTestRepo/exported-assets.js
@@ -1,1 +1,2 @@
-export { default as Vector } from './Vector.svg'
+export { default as Bg_shape } from './Bg_shape.svg'
+export { default as Vector_sliders } from './Vector_sliders.svg'


### PR DESCRIPTION
## Figma Assets to Github

This pull request contains a set of assets from your figma library:
- **Page:** builder
- **Panel:** FilterIcon

---

### Asset Configurations:

- **RTL Mode:** Disabled
- **RTL Page:** undefined
- **RTL Panel:** undefined
- **Export Format:** SVG

---

### Assets Exported:
- Total amount: 2
- Number of variants: 2 

---

<div align="center">
  <img width="50" height="50" align="center" src="https://raw.githubusercontent.com/knok-healthcare/figma-assets-to-github-plugin/b0d305451b4c5d3c720de825d0eb81b83ea39662/apps/ui/public/favicon/favicon_64.svg" />
</div>
  